### PR TITLE
Clean up code and adhere to RFC

### DIFF
--- a/include/lib9.h
+++ b/include/lib9.h
@@ -8,4 +8,4 @@ typedef unsigned long long int  uvlong;
 typedef unsigned int            u32int;
 typedef uvlong                  u64int;
 
-
+typedef unsigned short          ushort;

--- a/include/styx.h
+++ b/include/styx.h
@@ -20,6 +20,8 @@
 #define	BIT64SZ		8
 #define	QIDSZ	        (BIT8SZ+BIT32SZ+BIT64SZ)
 
+
+#define	NOTAG		(ushort)~0U	/* Dummy tag */
 #define	IOHDRSZ		24	/* ample room for Twrite/Rread header (iounit) */
 
 enum

--- a/include/styx.h
+++ b/include/styx.h
@@ -1,4 +1,4 @@
-/* copied from Inferno's include/styx.h file */
+/* copied from Inferno's include/styx.h and include/fcall.h file */
 #define	VERSION9P	"9P2000"
 #define	MAXWELEM	16
 
@@ -22,6 +22,7 @@
 
 
 #define	NOTAG		(ushort)~0U	/* Dummy tag */
+#define	NOFID		(u32int)~0U	/* Dummy fid */
 #define	IOHDRSZ		24	/* ample room for Twrite/Rread header (iounit) */
 
 enum

--- a/lib/styx.c
+++ b/lib/styx.c
@@ -50,17 +50,18 @@ void process_styx_message(uchar *msg, short len)
         u32int msize = GBIT32(&msg[3]);
 
         /* next 6 bytes is the string "9P2000" */
-        char *protover
-        asprintf(&protover, "%c%c%c%c%c%c", msg[7], msg[8], msg[9], msg[10], msg[11], msg[12]);
+        char protover[7];
+        strncpy(protover, 6, *msg+7);
+        protover[6] = '\0';
 
-        if (strcmp(protover, "9P2000") == 0) {
+
+        if (strcmp(protover, VERSION9P) == 0) {
             /* send Rversion */
         }
         else {
             /* send Rerror */
         }
 
-        free(protover);
         break;
     default:
     }

--- a/lib/styx.c
+++ b/lib/styx.c
@@ -31,15 +31,20 @@ const DirectoryEntry *qid_map[] = {
 
 uchar resp[16];
 
-void interpret(uchar *msg, short len)
+void process_styx_message(uchar *msg, short len)
 {
     uchar type = msg[0];
 
     switch (type) {
     case Tversion:
-        /* Tversion tag msize version == Tversion (-1) msize "9P2000" */
+        /*
+           Tversion[1] tag[2] msize[4] version[s]
+           Tversion NOTAG msize "9P2000"
+         */
+
         uchar tag = GBIT16(&msg[1]);
-        assert(tag == -1);
+        /* Client establishes with NOTAG  */
+        assert(tag == NOTAG);
 
         /* msize is 4 bytes */
         u32int msize = GBIT32(&msg[3]);
@@ -74,7 +79,7 @@ void process_message(uchar *msg, short len)
     msgsize = GBIT32(&msg[0]);
 
     if (msgsize > 0) {
-        interpret(&msg[4], msgsize - 4);
+        process_styx_message(&msg[4], msgsize - 4);
     }
 }
 


### PR DESCRIPTION
This pull request has following changes
* renamed `interpret` function as `process_styx_message`
* Improved Tversion comment to follow message structure followed by 9P protocol manuals
* Use `NOTAG` as mentioned in protocol RFC instead of -1
* Use strncpy instead of `asprintf`, it is not present in avr-libc 